### PR TITLE
avoid use of much slower tprod when both input matrices are 2D

### DIFF
--- a/external/svm/linKer.m
+++ b/external/svm/linKer.m
@@ -23,8 +23,12 @@ function K=linKer(X,Z,dir)
 
 if ( nargin < 2 ) Z=X; end;
 if ( nargin < 3 ) dir=1; end;
-if ( dir==-1 ) % dir indicates if row or col vectors
+if ( dir==-1 ) && (ndims(X)>2 || ndims(Z)>2)% dir indicates if row or col vectors
    K=tprod(X,[-(1:ndims(X)-1) 1],Z,[-(1:ndims(Z)-1) 2],'n');
-else
+elseif ( dir==-1)
+   K=transpose(X)*Z;
+elseif ( dir==1 ) && (ndims(X)>2 || ndims(Z)>2)
    K=tprod(X,[1 -(2:ndims(X))],Z,[2 -(2:ndims(Z))],'n');
+elseif ( dir==1 )
+   K=X*transpose(Z);
 end


### PR DESCRIPTION
This PR leads to a potential major speed up, the tensor product function (tprod) is relatively slow compared to plain matrix multiplication, when both input matrices are 2D. On a linux machine on our torque cluster, running matlab2014b a ~2000*8000 matrix multiplication runs in ~4 seconds, tprod takes about > 1 minute.